### PR TITLE
Updating pipeline dependencies: das-platform-building-blocks to 2.1.0 and das-platform-automation to 5.1.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,12 +4,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/0.4.74
+    ref: refs/tags/2.1.0
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.0.6
+    ref: refs/tags/5.1.4
     endpoint: SkillsFundingAgency
 
 trigger:

--- a/src/SFA.DAS.ToolsNotifications.Api/SFA.DAS.ToolsNotifications.Api.csproj
+++ b/src/SFA.DAS.ToolsNotifications.Api/SFA.DAS.ToolsNotifications.Api.csproj
@@ -17,6 +17,7 @@
     <!-- Transitive updates -->
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.*" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ToolsNotifications.Client/SFA.DAS.ToolsNotifications.Client.csproj
+++ b/src/SFA.DAS.ToolsNotifications.Client/SFA.DAS.ToolsNotifications.Client.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.6.48" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+
+    <!-- Transitive updates -->
+    <PackageReference Include="System.Drawing.Common" Version="5.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ToolsNotifications.Core/SFA.DAS.ToolsNotifications.Core.csproj
+++ b/src/SFA.DAS.ToolsNotifications.Core/SFA.DAS.ToolsNotifications.Core.csproj
@@ -10,5 +10,8 @@
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.ToolsNotifications.Client\SFA.DAS.ToolsNotifications.Client.csproj" />
     <ProjectReference Include="..\SFA.DAS.ToolsNotifications.Types\SFA.DAS.ToolsNotifications.Types.csproj" />
+
+    <!-- Transitive updates -->
+    <PackageReference Include="System.Drawing.Common" Version="5.0.*" />
   </ItemGroup>
 </Project>

--- a/src/SFA.DAS.ToolsNotifications.Infrastructure/SFA.DAS.ToolsNotifications.Infrastructure.csproj
+++ b/src/SFA.DAS.ToolsNotifications.Infrastructure/SFA.DAS.ToolsNotifications.Infrastructure.csproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.5" />
+
+    <!-- Transitive updates -->
+    <PackageReference Include="System.Drawing.Common" Version="5.0.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updating pipeline dependencies: das-platform-building-blocks to 2.1.0 and das-platform-automation to 5.1.4
- Pinned transitive package System.Drawing.Common to non-vulnerable version